### PR TITLE
Enhance oss fuz implementation for peak performance

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,37 @@
+name: Fuzz (Atheris)
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  atheris:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install fuzz requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-fuzz.txt
+
+      - name: Run schema-generator fuzzer (sanity)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python -m atheris fuzz/schema_generator_fuzz.py -only_ascii=1 -runs=50000
+
+      - name: Run supabase-schema-generator fuzzer (sanity)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python -m atheris fuzz/supabase_schema_generator_fuzz.py -only_ascii=1 -runs=50000
+

--- a/FUZZING.md
+++ b/FUZZING.md
@@ -1,0 +1,57 @@
+# Fuzzing Guide (Atheris)
+
+This repository includes Python fuzzers using Atheris to stress core generators and catch crashes/edge cases early.
+
+## Targets
+
+- `fuzz/schema_generator_fuzz.py`: Exercises `schema-generator.py`
+  - `pascale_to_snake`
+  - `generate_collection_schemas`
+  - `generate_relationship_tables`
+  - `generate_utility_functions`
+- `fuzz/supabase_schema_generator_fuzz.py`: Exercises `supabase-schema-generator.py`
+  - `pascale_to_snake`
+  - `generate_supabase_table_schema`
+  - `generate_supabase_migration`
+  - `generate_typescript_queries`
+
+## Quick Start (Local)
+
+```bash
+# From repo root
+./scripts/run-fuzz.sh schema_generator_fuzz
+./scripts/run-fuzz.sh supabase_schema_generator_fuzz
+```
+
+The script bootstraps a venv, installs `requirements-fuzz.txt`, and runs Atheris with sane defaults.
+
+To pass custom flags to Atheris, append them after the target name:
+
+```bash
+./scripts/run-fuzz.sh schema_generator_fuzz -runs=100000 -only_ascii=1
+```
+
+## Seed Corpora
+
+- `fuzz/corpora/schema_generator`
+- `fuzz/corpora/supabase_schema_generator`
+
+Add more minimized, interesting inputs over time. Keep corpora small and meaningful.
+
+## CI
+
+A GitHub Action at `.github/workflows/fuzz.yml` runs both fuzzers with a finite number of iterations on PRs and `main` pushes.
+
+## Guidelines
+
+- Keep fuzz harnesses side-effect free: do not write files or connect to databases.
+- Make optional imports tolerant (e.g., psycopg2) to avoid import-time crashes in minimal environments.
+- When a crash is found, add the minimized input to the appropriate corpus and include a regression test where relevant.
+- Prefer deterministic, bounded runs in CI (`-runs=N`). Use unbounded runs locally for deeper discovery.
+
+## Troubleshooting
+
+- If imports fail, ensure `PYTHONPATH` includes the repo root.
+- If you see UnicodeDecodeError, keep `-only_ascii=1` while debugging.
+- Use `-timeout=10` to abort long hangs during triage.
+

--- a/fuzz/corpora/schema_generator
+++ b/fuzz/corpora/schema_generator
@@ -1,0 +1,1 @@
+[{"collections":["Users","Orders","BlogPosts","SEOSettings"]}]

--- a/fuzz/corpora/supabase_schema_generator
+++ b/fuzz/corpora/supabase_schema_generator
@@ -1,0 +1,1 @@
+{"collections":["Services","Products","BlogPosts","Media","Users"]}

--- a/fuzz/schema_generator_fuzz.py
+++ b/fuzz/schema_generator_fuzz.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Fuzzer for schema-generator.py using Atheris.
+
+Targets:
+- SchemaGenerator.pascale_to_snake
+- SchemaGenerator.generate_collection_schemas
+- SchemaGenerator.generate_relationship_tables
+- SchemaGenerator.generate_utility_functions
+"""
+
+import sys
+import atheris
+import json
+import io
+import os
+import importlib.util
+from typing import Any, Dict, List
+
+
+def _load_module(filepath: str, module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, filepath)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load module from {filepath}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    return mod
+
+
+SCHEMA_MOD = _load_module(os.path.join(os.path.dirname(__file__), "..", "schema-generator.py"),
+                          "schema_generator_module")
+
+
+def _bytes_to_strings(data: bytes) -> List[str]:
+    try:
+        s = data.decode("utf-8", errors="ignore")
+    except Exception:
+        s = ""
+    # Split into tokens; keep some variants
+    tokens = [t for t in s.replace("\n", " ").replace("\t", " ").split(" ") if t]
+    # Ensure at least one reasonable default
+    if not tokens:
+        tokens = ["Users", "Orders", "BlogPosts"]
+    # Cap to avoid extreme sizes
+    return tokens[:50]
+
+
+def _build_collections_info(data: bytes) -> Dict[str, Any]:
+    # Try to parse as JSON dictionary with "collections"
+    try:
+        parsed = json.loads(data.decode("utf-8", errors="ignore"))
+        if isinstance(parsed, dict) and isinstance(parsed.get("collections"), list):
+            # Coerce all items to strings
+            collections = [str(x)[:100] for x in parsed.get("collections", [])][:200]
+            return {"collections": collections}
+    except Exception:
+        pass
+
+    # Fallback: derive from string tokens
+    tokens = _bytes_to_strings(data)
+    # Normalize to plausible PascalCase identifiers to explore name logic
+    normalized = []
+    for t in tokens:
+        t_stripped = "".join(ch for ch in t if ch.isalnum())
+        if not t_stripped:
+            continue
+        normalized.append(t_stripped[:60].capitalize())
+    if not normalized:
+        normalized = ["Users", "Orders"]
+    return {"collections": normalized[:200]}
+
+
+def TestOneInput(data: bytes) -> None:
+    gen = SCHEMA_MOD.SchemaGenerator()
+    # Inject fuzzed collections info to avoid file I/O
+    gen.collections_info = _build_collections_info(data)
+
+    # Exercise name conversion on several strings
+    for token in _bytes_to_strings(data)[:10]:
+        _ = gen.pascale_to_snake(token)
+
+    # Generate schemas and utility strings
+    schemas = gen.generate_collection_schemas()
+    _ = gen.generate_relationship_tables()
+    _ = gen.generate_utility_functions()
+
+    # Lightly exercise concatenation path to catch format issues
+    # Avoid writing files or DB sync during fuzzing
+    _ = len("\n".join(schemas))
+
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/fuzz/supabase_schema_generator_fuzz.py
+++ b/fuzz/supabase_schema_generator_fuzz.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+Fuzzer for supabase-schema-generator.py using Atheris.
+
+Targets:
+- SupabaseSchemaGenerator.pascale_to_snake
+- SupabaseSchemaGenerator.generate_supabase_table_schema
+- SupabaseSchemaGenerator.generate_supabase_migration
+- SupabaseSchemaGenerator.generate_typescript_queries
+"""
+
+import sys
+import atheris
+import json
+import io
+import os
+import importlib.util
+from typing import Any, Dict, List
+
+
+def _load_module(filepath: str, module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, filepath)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load module from {filepath}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    return mod
+
+
+SUPABASE_MOD = _load_module(os.path.join(os.path.dirname(__file__), "..", "supabase-schema-generator.py"),
+                            "supabase_schema_generator_module")
+
+
+def _bytes_to_strings(data: bytes) -> List[str]:
+    try:
+        s = data.decode("utf-8", errors="ignore")
+    except Exception:
+        s = ""
+    tokens = [t for t in s.replace("\n", " ").replace("\t", " ").split(" ") if t]
+    if not tokens:
+        tokens = ["Services", "Products", "BlogPosts"]
+    return tokens[:50]
+
+
+def _build_collections_info(data: bytes) -> Dict[str, Any]:
+    try:
+        parsed = json.loads(data.decode("utf-8", errors="ignore"))
+        if isinstance(parsed, dict) and isinstance(parsed.get("collections"), list):
+            collections = [str(x)[:100] for x in parsed.get("collections", [])][:200]
+            return {"collections": collections}
+    except Exception:
+        pass
+
+    tokens = _bytes_to_strings(data)
+    normalized = []
+    for t in tokens:
+        t_stripped = "".join(ch for ch in t if ch.isalnum())
+        if not t_stripped:
+            continue
+        normalized.append(t_stripped[:60].capitalize())
+    if not normalized:
+        normalized = ["Services", "Products"]
+    return {"collections": normalized[:200]}
+
+
+def TestOneInput(data: bytes) -> None:
+    gen = SUPABASE_MOD.SupabaseSchemaGenerator()
+    gen.collections_info = _build_collections_info(data)
+
+    # Name conversion
+    for token in _bytes_to_strings(data)[:10]:
+        _ = gen.pascale_to_snake(token)
+
+    # Generate per-table schema for a few names
+    for name in gen.collections_info.get("collections", [])[:5]:
+        table = gen.pascale_to_snake(name)
+        _ = gen.generate_supabase_table_schema(table, name)
+
+    # Generate whole migration and TS queries
+    _ = gen.generate_supabase_migration()
+    _ = gen.generate_typescript_queries()
+
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/requirements-fuzz.txt
+++ b/requirements-fuzz.txt
@@ -1,0 +1,3 @@
+atheris>=2.3.0
+pytest>=8.2.0
+numpy>=1.26.0; python_version>='3.9'

--- a/schema-generator.py
+++ b/schema-generator.py
@@ -10,7 +10,10 @@ import re
 from pathlib import Path
 from typing import Dict, List, Any, Optional, Set
 import subprocess
-import psycopg2
+try:
+	import psycopg2  # type: ignore
+except Exception:  # pragma: no cover - optional for fuzzing environments
+	psycopg2 = None  # type: ignore
 from datetime import datetime
 
 class SchemaGenerator:

--- a/scripts/run-fuzz.sh
+++ b/scripts/run-fuzz.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f requirements-fuzz.txt ]]; then
+  echo "Run from repo root where requirements-fuzz.txt exists" >&2
+  exit 1
+fi
+
+python3 -m venv .venv-fuzz
+source .venv-fuzz/bin/activate
+pip install --upgrade pip
+pip install -r requirements-fuzz.txt
+
+# Ensure PYTHONPATH includes repo root
+export PYTHONPATH="$(pwd):${PYTHONPATH:-}"
+
+FUZZ_TARGET=${1:-schema_generator_fuzz}
+shift || true
+
+echo "Running fuzz target: ${FUZZ_TARGET}"
+python -m atheris "fuzz/${FUZZ_TARGET}.py" -only_ascii=1 -timeout=10 -atheris_runs=0 "$@"


### PR DESCRIPTION
## Summary

This PR introduces Atheris-based fuzzing for `schema-generator.py` and `supabase-schema-generator.py` to proactively identify bugs, crashes, and edge cases in the core schema generation logic.

To enable fuzzing in minimal environments, `psycopg2` has been made an optional import in `schema-generator.py`.

## Security Checklist

- [x] No secrets or credentials are added
- [ ] New endpoints validated (authZ/authN, input validation) - N/A, no new endpoints
- [ ] User data handling follows policy (PII, logging, retention) - N/A, no user data handled
- [ ] If fixing a security issue, linked to private advisory or issue - N/A, proactive fuzzing
- [ ] Added/updated tests cover the vulnerable code path(s) - N/A, fuzzing is a testing methodology

## Testing

-   **Local:**
    -   Install fuzz requirements: `pip install -r requirements-fuzz.txt`
    -   Run a fuzzer: `./scripts/run-fuzz.sh schema_generator_fuzz` or `./scripts/run-fuzz.sh supabase_schema_generator_fuzz`
    -   Refer to `FUZZING.md` for more details and options.
-   **CI:** A GitHub Action (`.github/workflows/fuzz.yml`) runs bounded fuzzing iterations on PRs and `main` pushes.

## Linked Issues

- Closes #
- Related #

---
<a href="https://cursor.com/background-agent?bcId=bc-1f0bed7d-84ac-4871-8bfb-55f91ab920d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f0bed7d-84ac-4871-8bfb-55f91ab920d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Introduce Atheris-based fuzzing for schema-generator and supabase-schema-generator to detect crashes and edge cases early, make psycopg2 optional for minimal environments, and integrate fuzzing into CI and documentation.

New Features:
- Add Atheris fuzz harness scripts for schema-generator and supabase-schema-generator to proactively identify bugs and edge cases
- Provide a bash script for local fuzzing (scripts/run-fuzz.sh) and add requirements-fuzz.txt for dependencies

Enhancements:
- Make psycopg2 an optional import in schema-generator to support fuzzing in minimal environments

Build:
- Add requirements-fuzz.txt to manage fuzzing dependencies

CI:
- Add GitHub Actions workflow to run bounded Atheris fuzzing on pull requests and main pushes

Documentation:
- Add FUZZING.md with a guide for running and maintaining fuzzers, including seed corpora and CI usage

Tests:
- Add Atheris-based fuzz tests covering core schema generation functions in both generators